### PR TITLE
View frustum optimisations

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use glium::glutin::event::Event;
 use glium::glutin::event_loop::{ControlFlow, EventLoop};
 use glium::Display;
 use input::{Input, InputEvent};
+use render::camera::{Camera, CameraSystem};
 use render::renderer::{RenderMesh, RenderingSystem, RENDER_DISTANCE};
 use specs::WorldExt;
 
@@ -19,7 +20,6 @@ mod util;
 mod world;
 
 use world::ecs::bounds::Bounds;
-use world::ecs::camera::{Camera, CameraSystem};
 use world::ecs::chunk_loader::{ChunkGenerator, ChunkLoader};
 use world::ecs::physics::{Physics, Rigidbody};
 use world::ecs::player::{Player, PlayerMovement};

--- a/src/main.rs
+++ b/src/main.rs
@@ -138,7 +138,6 @@ fn main() {
                 last_frame = frame_start;
 
                 world.write_resource::<DeltaTime>().0 = delta_time;
-                // world.write_resource::<ElapsedTime>().0 += delta_time;
 
                 dispatcher.dispatch(&mut world);
                 world.maintain();

--- a/src/render/camera.rs
+++ b/src/render/camera.rs
@@ -48,6 +48,7 @@ impl<'a> System<'a> for CameraSystem {
             vector3!(0.0, 1.0, 0.0),
         );
         camera.calculate_projection_matrix();
+        camera.calculate_view_frustum(transform.position);
 
         let sensitivity = 50.0;
 
@@ -69,6 +70,7 @@ pub struct Camera {
     pub fov: f32,
     view_matrix: [[f32; 4]; 4],
     projection_matrix: [[f32; 4]; 4],
+    view_frustum: ViewFrustum,
 }
 
 impl Default for Camera {
@@ -83,6 +85,7 @@ impl Default for Camera {
             fov: 3.141592 / 3.0,
             view_matrix: [[0.0; 4]; 4],
             projection_matrix: [[0.0; 4]; 4],
+            view_frustum: ViewFrustum::default(),
         };
         cam.calculate_projection_matrix();
         cam
@@ -168,16 +171,9 @@ impl Camera {
         ];
     }
 
-    pub fn is_mesh_visible(
-        &self,
-        transform: &Transform,
-
-        // TODO: make mesh bounds relative to the mesh, and use mesh_origin to transform them to world space
-        mesh_origin: Vector3<f32>,
-        mesh: &Mesh,
-    ) -> bool {
-        let view_frustum = ViewFrustum::new(
-            transform.position,
+    fn calculate_view_frustum(&mut self, pos: Vector3<f32>) {
+        self.view_frustum = ViewFrustum::new(
+            pos,
             self.look_direction(),
             self.look_rotation() * vector3!(0.0, 1.0, 0.0),
             self.fov,
@@ -185,6 +181,14 @@ impl Camera {
             self.far_dist,
             self.aspect_ratio,
         );
-        view_frustum.contains_box(mesh.bounds())
+    }
+
+    pub fn is_mesh_visible(
+        &self,
+        // TODO: make mesh bounds relative to the mesh, and use mesh_origin to transform them to world space
+        mesh_origin: Vector3<f32>,
+        mesh: &Mesh,
+    ) -> bool {
+        self.view_frustum.contains_box(mesh.bounds())
     }
 }

--- a/src/render/camera.rs
+++ b/src/render/camera.rs
@@ -1,15 +1,15 @@
-use cgmath::{num_traits::Signed, prelude::*, Deg, Euler, Point3, Quaternion, Rad, Vector3};
+use cgmath::{Angle, Deg, Euler, InnerSpace, Quaternion, Rad, Vector3};
 use specs::{Component, Entity, Read, ReadStorage, System, VecStorage, WriteStorage};
 
 use crate::{
     input::Input,
     render::{mesh::Mesh, renderer::RENDER_DISTANCE},
     vector3,
-    world::CHUNK_SIZE,
+    world::{ecs::Transform, CHUNK_SIZE},
     DeltaTime,
 };
 
-use super::{bounds::Bounds, Transform};
+use super::culling::ViewFrustum;
 
 /// Runs on a single `Entity` designated as the camera. This entity must have a `Transform` component otherwise the system will fail.
 pub struct CameraSystem {
@@ -186,129 +186,5 @@ impl Camera {
             self.aspect_ratio,
         );
         view_frustum.contains_box(mesh.bounds())
-    }
-}
-
-#[derive(Debug)]
-struct ViewFrustum {
-    planes: [Plane; 6],
-}
-
-impl ViewFrustum {
-    pub fn new(
-        pos: Vector3<f32>,
-        dir: Vector3<f32>,
-        up: Vector3<f32>,
-        fov: f32,
-        near: f32,
-        far: f32,
-        aspect_ratio: f32,
-    ) -> Self {
-        let h_near = (fov / 2.0).tan() * near;
-        let w_near = h_near * aspect_ratio;
-
-        let z = -dir;
-        let x = (up.cross(z)).normalize();
-        let y = z.cross(x);
-
-        let (nc, fc) = (pos - z * near, pos - z * far);
-
-        Self {
-            planes: [
-                Plane {
-                    point: nc,
-                    normal: -z,
-                },
-                Plane {
-                    point: fc,
-                    normal: z,
-                },
-                Plane {
-                    point: nc + y * h_near,
-                    normal: ((nc + y * h_near) - pos).normalize().cross(x),
-                },
-                Plane {
-                    point: nc - y * h_near,
-                    normal: x.cross(((nc - y * h_near) - pos).normalize()),
-                },
-                Plane {
-                    point: nc - x * w_near,
-                    normal: ((nc - x * w_near) - pos).normalize().cross(y),
-                },
-                Plane {
-                    point: nc + x * w_near,
-                    normal: y.cross(((nc + x * w_near) - pos).normalize()),
-                },
-            ],
-        }
-    }
-
-    pub fn contains_box(&self, bounds: Bounds) -> bool {
-        let contains = true;
-        for p in self.planes.iter() {
-            let (mut v_in, mut v_out) = (0_u32, 0_u32);
-
-            let vs = bounds.vertices();
-            for v in &vs {
-                if p.distance(*v).is_negative() {
-                    v_out += 1;
-                } else {
-                    v_in += 1;
-                }
-
-                if v_out > 0 && v_in > 0 {
-                    break;
-                }
-            }
-
-            if v_in == 0 {
-                return false;
-            }
-        }
-
-        contains
-    }
-}
-
-#[derive(Debug)]
-struct Plane {
-    point: Vector3<f32>,
-    normal: Vector3<f32>,
-}
-
-impl Plane {
-    pub fn distance(&self, pos: Vector3<f32>) -> f32 {
-        (pos - self.point).dot(self.normal)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::vector3;
-
-    use super::Plane;
-
-    #[test]
-    fn test_plane_distance() {
-        let pos = vector3!(5.0, 5.0, 0.0);
-
-        let plane = Plane {
-            point: vector3!(0.0, 0.0, 0.0),
-            normal: vector3!(1.0, 0.0, 0.0),
-        };
-
-        assert_eq!(plane.distance(pos), 5.0);
-    }
-
-    #[test]
-    fn test_plane_negative_distance() {
-        let pos = vector3!(-5.0, 5.0, 10.0);
-
-        let plane = Plane {
-            point: vector3!(0.0, 0.0, 0.0),
-            normal: vector3!(1.0, 0.0, 0.0),
-        };
-
-        assert_eq!(plane.distance(pos), -5.0);
     }
 }

--- a/src/render/culling.rs
+++ b/src/render/culling.rs
@@ -1,8 +1,8 @@
-use cgmath::{num_traits::Signed, InnerSpace, Vector3};
+use cgmath::{num_traits::Signed, InnerSpace, Vector3, Zero};
 
 use crate::world::ecs::bounds::Bounds;
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, Default)]
 pub struct ViewFrustum {
     planes: [Plane; 6],
 }
@@ -83,7 +83,7 @@ impl ViewFrustum {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 struct Plane {
     point: Vector3<f32>,
     normal: Vector3<f32>,
@@ -92,6 +92,15 @@ struct Plane {
 impl Plane {
     fn distance(&self, pos: Vector3<f32>) -> f32 {
         (pos - self.point).dot(self.normal)
+    }
+}
+
+impl Default for Plane {
+    fn default() -> Self {
+        Self {
+            point: Vector3::zero(),
+            normal: Vector3::zero(),
+        }
     }
 }
 

--- a/src/render/culling.rs
+++ b/src/render/culling.rs
@@ -1,0 +1,127 @@
+use cgmath::{num_traits::Signed, InnerSpace, Vector3};
+
+use crate::world::ecs::bounds::Bounds;
+
+#[derive(Debug)]
+pub struct ViewFrustum {
+    planes: [Plane; 6],
+}
+
+impl ViewFrustum {
+    pub fn new(
+        pos: Vector3<f32>,
+        dir: Vector3<f32>,
+        up: Vector3<f32>,
+        fov: f32,
+        near: f32,
+        far: f32,
+        aspect_ratio: f32,
+    ) -> Self {
+        let h_near = (fov / 2.0).tan() * near;
+        let w_near = h_near * aspect_ratio;
+
+        let z = -dir;
+        let x = (up.cross(z)).normalize();
+        let y = z.cross(x);
+
+        let (nc, fc) = (pos - z * near, pos - z * far);
+
+        Self {
+            planes: [
+                Plane {
+                    point: nc,
+                    normal: -z,
+                },
+                Plane {
+                    point: fc,
+                    normal: z,
+                },
+                Plane {
+                    point: nc + y * h_near,
+                    normal: ((nc + y * h_near) - pos).normalize().cross(x),
+                },
+                Plane {
+                    point: nc - y * h_near,
+                    normal: x.cross(((nc - y * h_near) - pos).normalize()),
+                },
+                Plane {
+                    point: nc - x * w_near,
+                    normal: ((nc - x * w_near) - pos).normalize().cross(y),
+                },
+                Plane {
+                    point: nc + x * w_near,
+                    normal: y.cross(((nc + x * w_near) - pos).normalize()),
+                },
+            ],
+        }
+    }
+
+    pub fn contains_box(&self, bounds: Bounds) -> bool {
+        let contains = true;
+        for p in self.planes.iter() {
+            let (mut v_in, mut v_out) = (0_u32, 0_u32);
+
+            let vs = bounds.vertices();
+            for v in &vs {
+                if p.distance(*v).is_negative() {
+                    v_out += 1;
+                } else {
+                    v_in += 1;
+                }
+
+                if v_out > 0 && v_in > 0 {
+                    break;
+                }
+            }
+
+            if v_in == 0 {
+                return false;
+            }
+        }
+
+        contains
+    }
+}
+
+#[derive(Debug)]
+struct Plane {
+    point: Vector3<f32>,
+    normal: Vector3<f32>,
+}
+
+impl Plane {
+    fn distance(&self, pos: Vector3<f32>) -> f32 {
+        (pos - self.point).dot(self.normal)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::vector3;
+
+    use super::Plane;
+
+    #[test]
+    fn test_plane_distance() {
+        let pos = vector3!(5.0, 5.0, 0.0);
+
+        let plane = Plane {
+            point: vector3!(0.0, 0.0, 0.0),
+            normal: vector3!(1.0, 0.0, 0.0),
+        };
+
+        assert_eq!(plane.distance(pos), 5.0);
+    }
+
+    #[test]
+    fn test_plane_negative_distance() {
+        let pos = vector3!(-5.0, 5.0, 10.0);
+
+        let plane = Plane {
+            point: vector3!(0.0, 0.0, 0.0),
+            normal: vector3!(1.0, 0.0, 0.0),
+        };
+
+        assert_eq!(plane.distance(pos), -5.0);
+    }
+}

--- a/src/render/mesh.rs
+++ b/src/render/mesh.rs
@@ -1,9 +1,12 @@
 use uuid::Uuid;
 
+use crate::{vector3, world::ecs::bounds::Bounds};
+
 pub struct Mesh {
     pub id: Uuid,
     pub vertices: Vec<Vertex>,
     pub triangles: Vec<u32>,
+    mesh_bounds: Bounds,
 }
 
 impl Mesh {
@@ -12,11 +15,67 @@ impl Mesh {
     }
 
     pub fn new_with_id(id: Uuid, vertices: Vec<Vertex>, triangles: Vec<u32>) -> Self {
-        Self {
+        let mut mesh = Self {
             id,
             vertices,
             triangles,
-        }
+            mesh_bounds: Bounds::new(vector3!(0.0, 0.0, 0.0), vector3!(0.0, 0.0, 0.0)),
+        };
+        mesh.recalculate_bounds();
+        mesh
+    }
+
+    pub fn recalculate_bounds(&mut self) {
+        let x_min = self
+            .vertices
+            .iter()
+            .min_by(|a, b| a.position[0].total_cmp(&b.position[0]))
+            .unwrap()
+            .position[0];
+        let x_max = self
+            .vertices
+            .iter()
+            .max_by(|a, b| a.position[0].total_cmp(&b.position[0]))
+            .unwrap()
+            .position[0];
+        let y_min = self
+            .vertices
+            .iter()
+            .min_by(|a, b| a.position[1].total_cmp(&b.position[1]))
+            .unwrap()
+            .position[1];
+        let y_max = self
+            .vertices
+            .iter()
+            .max_by(|a, b| a.position[1].total_cmp(&b.position[1]))
+            .unwrap()
+            .position[1];
+        let z_min = self
+            .vertices
+            .iter()
+            .min_by(|a, b| a.position[2].total_cmp(&b.position[2]))
+            .unwrap()
+            .position[2];
+        let z_max = self
+            .vertices
+            .iter()
+            .max_by(|a, b| a.position[2].total_cmp(&b.position[2]))
+            .unwrap()
+            .position[2];
+
+        let (x_diff, y_diff, z_diff) = (x_max - x_min, y_max - y_min, z_max - z_min);
+        self.mesh_bounds = Bounds::new(
+            vector3!(
+                x_min + x_diff / 2.0,
+                y_min + y_diff / 2.0,
+                z_min + z_diff / 2.0
+            ),
+            vector3!(x_diff, y_diff, z_diff),
+        );
+    }
+
+    pub fn bounds(&self) -> Bounds {
+        self.mesh_bounds
     }
 }
 

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -1,3 +1,5 @@
+pub mod camera;
+mod culling;
 pub mod material;
 pub mod mesh;
 pub mod primitives;

--- a/src/render/renderer.rs
+++ b/src/render/renderer.rs
@@ -19,12 +19,10 @@ use specs::{
 };
 use uuid::Uuid;
 
-use crate::{
-    vector3,
-    world::ecs::{bounds::Bounds, camera::Camera, Transform},
-};
+use crate::world::ecs::{bounds::Bounds, Transform};
 
 use super::{
+    camera::Camera,
     material::{load_shader, load_texture, Material},
     mesh::{Mesh, Vertex},
 };
@@ -282,7 +280,7 @@ struct MemoryAllocation {
     count: usize,
 }
 
-pub const RENDER_DISTANCE: usize = 16;
+pub const RENDER_DISTANCE: usize = 32;
 
 // For a render distance r, we can load (2r)^2 chunks around the player.
 // If none of these are culled, we need a draw command for each chunk. Therefore command buffer should be have room for at least (2r)^2 commands.

--- a/src/render/renderer.rs
+++ b/src/render/renderer.rs
@@ -79,11 +79,7 @@ impl<'a> System<'a> for RenderingSystem {
             .par_join()
             .filter_map(|(transform, mesh_data, bounds)| {
                 if !mesh_data.visible
-                    || !camera.is_mesh_visible(
-                        camera_transform,
-                        transform.position,
-                        &mesh_data.mesh,
-                    )
+                    || !camera.is_mesh_visible(transform.position, &mesh_data.mesh)
                 {
                     return None;
                 }

--- a/src/world/ecs/bounds.rs
+++ b/src/world/ecs/bounds.rs
@@ -3,7 +3,7 @@ use specs::{Component, VecStorage};
 
 use crate::vector3;
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub struct Bounds {
     pub origin: Vector3<f32>,
     pub dimensions: Vector3<f32>,

--- a/src/world/ecs/chunk_loader.rs
+++ b/src/world/ecs/chunk_loader.rs
@@ -7,12 +7,12 @@ use cgmath::{InnerSpace, One, Quaternion, Vector2, Vector3, Zero};
 use specs::{prelude::*, rayon::prelude::IntoParallelRefIterator};
 
 use crate::{
-    render::{mesh::Mesh, renderer::RenderMesh},
+    render::{camera::Camera, mesh::Mesh, renderer::RenderMesh},
     vector2, vector3,
     world::{Chunk, CHUNK_SIZE, WORLD_HEIGHT},
 };
 
-use super::{bounds::Bounds, camera::Camera, Transform};
+use super::{bounds::Bounds, Transform};
 pub struct ChunkGenerator {
     generate_distance: u32,
 }

--- a/src/world/ecs/mod.rs
+++ b/src/world/ecs/mod.rs
@@ -4,7 +4,6 @@ use crate::vector3;
 use cgmath::{One, Quaternion, Vector3};
 
 pub mod bounds;
-pub mod camera;
 pub mod chunk_loader;
 pub mod physics;
 pub mod player;

--- a/src/world/ecs/player.rs
+++ b/src/world/ecs/player.rs
@@ -2,9 +2,9 @@ use cgmath::{Deg, Euler, Quaternion, Vector3};
 use glium::glutin::event::VirtualKeyCode;
 use specs::{Component, Join, Read, ReadStorage, System, VecStorage, WriteStorage};
 
-use crate::input::Input;
+use crate::{input::Input, render::camera::Camera};
 
-use super::{camera::Camera, physics::Rigidbody, Transform};
+use super::{physics::Rigidbody, Transform};
 
 #[derive(Default)]
 pub struct Player {}


### PR DESCRIPTION
Optimises view frustum culling based on axis-aligned bounding boxes for chunk meshes. Implemented according to the [geometric approach](http://www.lighthouse3d.com/tutorials/view-frustum-culling/).